### PR TITLE
#10 Fix inconsistency with Redis cache-key

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "BCOS",
     "hget",
     "hset",
+    "promisify",
     "virtuals"
   ]
 }

--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@
  */
 
 const express = require("express");
+const cors = require("cors");
 const productRouter = require("./routes/productRouter");
 const userRouter = require("./routes/userRouter");
 const errorController = require("./controllers/errorController");
@@ -15,20 +16,21 @@ require("./services/cache");
 
 const app = express();
 
+app.use(cors());
+
 app.use(express.json());
 
 app.use("/api/v1/products", productRouter);
 app.use("/api/v1/users", userRouter);
 
 app.use("*", (req, _res, next) => {
-	next(
-		new AppError(
-			`can't find ${req.originalUrl}, with the method:${req.method}, on this server!`
-		)
-	);
+  next(
+    new AppError(
+      `can't find ${req.originalUrl}, with the method:${req.method}, on this server!`
+    )
+  );
 });
 
 app.use(errorController);
 
 module.exports = app;
-

--- a/services/cache.js
+++ b/services/cache.js
@@ -4,63 +4,64 @@ const redis = require("redis");
 const devLog = require("../utils/devLog");
 
 const clearHash = (hashKey) => {
-	devLog(`> "${hashKey}" CACHE, HAS BEEN CLEANED`);
+  devLog(`> "${hashKey}" CACHE, HAS BEEN CLEANED`);
 
-	redisClient.del(JSON.stringify(hashKey));
+  redisClient.del(JSON.stringify(hashKey));
 };
 
-const redisUrl = "redis://127.0.0.1:6379";
-const redisClient = redis.createClient(redisUrl);
+const redisClient = redis.createClient(process.env.REDIS_URI);
 
 // redisClient.flushall();
 
 const exec = mongoose.Query.prototype.exec;
 
 mongoose.Query.prototype.cache = function (options = {}) {
-	this._cache = true;
-	this._hashKey = JSON.stringify(options.key || "");
+  this._cache = true;
+  this._hashKey = JSON.stringify(options.key || "");
 
-	return this;
+  return this;
 };
 
 mongoose.Query.prototype.exec = async function () {
-	if (!this._cache) {
-		devLog("> THIS QUERY IS NOT CACHED!");
-		return await exec.apply(this, arguments);
-	}
+  if (!this._cache) {
+    devLog("> THIS QUERY IS NOT CACHED!");
+    return await exec.apply(this, arguments);
+  }
 
-	const key = JSON.stringify({
-		...this.getQuery(),
-		collection: this.mongooseCollection.name,
-	});
+  const key = JSON.stringify({
+    ...this.getQuery(),
+    ...this.options,
+    collection: this.mongooseCollection.name,
+  });
 
-	redisClient.hget = promisify(redisClient.hget);
-	const cachedValue = await redisClient.hget(this._hashKey, key);
+  console.log(this._hashKey, key, this.getQuery(), this.options);
 
-	if (cachedValue) {
-		// ************* Why this won't work fine is BCOS `this.model(<object>)` not a <array>, and `cachedValue` could be an Array ********* //
-		// const doc = new this.model(JSON.parse(cachedValue));
-		// return doc;
+  redisClient.hget = promisify(redisClient.hget);
+  const cachedValue = await redisClient.hget(this._hashKey, key);
 
-		const convertToDocument = (plainJSON) => new this.model(plainJSON);
+  if (cachedValue) {
+    // ************* Why this won't work fine is BCOS `this.model(<object>)` not a <array>, and `cachedValue` could be an Array ********* //
+    // const doc = new this.model(JSON.parse(cachedValue));
+    // return doc;
 
-		let cachedDoc = JSON.parse(cachedValue);
-		cachedDoc = Array.isArray(cachedDoc)
-			? cachedDoc.map(convertToDocument)
-			: convertToDocument(cachedDoc);
+    const convertToDocument = (plainJSON) => new this.model(plainJSON);
 
-		devLog("> SERVING DATA FROM REDIS SERVER");
-		return cachedDoc;
-	}
+    let cachedDoc = JSON.parse(cachedValue);
+    cachedDoc = Array.isArray(cachedDoc)
+      ? cachedDoc.map(convertToDocument)
+      : convertToDocument(cachedDoc);
 
-	const result = await exec.apply(this, arguments);
-	redisClient.hset(this._hashKey, key, JSON.stringify(result));
+    devLog("> SERVING DATA FROM REDIS SERVER");
+    return cachedDoc;
+  }
 
-	devLog("> SERVING DATA FROM MONGODB");
-	return result;
+  const result = await exec.apply(this, arguments);
+  redisClient.hset(this._hashKey, key, JSON.stringify(result));
+
+  devLog("> SERVING DATA FROM MONGODB");
+  return result;
 };
 
 module.exports = {
-	clearHash,
+  clearHash,
 };
-

--- a/utils/APIFeatures.js
+++ b/utils/APIFeatures.js
@@ -1,64 +1,63 @@
 class APIFeatures {
-	constructor(mongooseQuery, reqQuery) {
-		this.Query = mongooseQuery;
-		this.queryString = reqQuery;
-	}
+  constructor(mongooseQuery, reqQuery) {
+    this.Query = mongooseQuery;
+    this.queryString = reqQuery;
+  }
 
-	filter = () => {
-		let queryObject = { ...this.queryString };
-		// Delete special params fields
-		const excludedFields = ["fields", "page", "limit", "sort"];
-		excludedFields.forEach((field) =>
-			Reflect.deleteProperty(queryObject, field)
-		);
+  filter = () => {
+    let queryObject = { ...this.queryString };
+    // Delete special params fields
+    const excludedFields = ["fields", "page", "limit", "sort"];
+    excludedFields.forEach((field) =>
+      Reflect.deleteProperty(queryObject, field)
+    );
 
-		let queryString = JSON.stringify(queryObject);
-		const replacePat = /(gt|lt|gte|lte)/;
-		const replaceFn = (match) => `$${match}`;
-		queryString = queryString.replace(replacePat, replaceFn);
+    let queryString = JSON.stringify(queryObject);
+    const replacePat = /(gt|lt|gte|lte)/;
+    const replaceFn = (match) => `$${match}`;
+    queryString = queryString.replace(replacePat, replaceFn);
 
-		queryObject = JSON.parse(queryString);
-		this.Query.find(queryObject);
+    queryObject = JSON.parse(queryString);
+    this.Query.find(queryObject);
 
-		return this;
-	};
+    return this;
+  };
 
-	sort = () => {
-		if (this.queryString.sort) {
-			let sortBy = this.queryString.sort;
-			sortBy = sortBy.replace(/,/g, " ");
+  sort = () => {
+    if (this.queryString.sort) {
+      let sortBy = this.queryString.sort;
+      sortBy = sortBy.replace(/,/g, " ");
 
-			this.Query = this.Query.sort(sortBy);
-		} else {
-			this.Query = this.Query.sort("-createdAt");
-		}
+      this.Query.sort(sortBy);
+    } else {
+      this.Query.sort("-createdAt");
+    }
 
-		return this;
-	};
+    return this;
+  };
 
-	project = () => {
-		if (this.queryString.fields) {
-			let fields = this.queryString.fields;
-			fields = fields.replace(/,/g, " ");
+  project = () => {
+    if (this.queryString.fields) {
+      let fields = this.queryString.fields;
+      fields = fields.replace(/,/g, " ");
 
-			this.Query = this.Query.select(fields);
-		} else {
-			this.Query = this.Query.select("-__v");
-		}
+      this.Query.select(fields);
+    } else {
+      this.Query.select("-__v");
+    }
 
-		return this;
-	};
+    return this;
+  };
 
-	paginate = () => {
-		const page = this.queryString.page * 1 || 1;
-		const limit = this.queryString.limit * 1 || 100;
-		const numberOfDocsToSkip = (page - 1) * limit;
+  paginate = () => {
+    const page = this.queryString.page * 1 || 1;
+    const limit = this.queryString.limit * 1 || 100;
+    const numberOfDocsToSkip = (page - 1) * limit;
 
-		this.Query = this.Query.limit(limit).skip(numberOfDocsToSkip);
+    this.Query.limit(limit).skip(numberOfDocsToSkip);
 
-		return this;
-	};
+    return this;
+  };
 }
 
 module.exports = APIFeatures;
-


### PR DESCRIPTION

#### What does this PR do?

Fix unnecessary Redis serving:

Add the query `option` to the `second-key`, for consistency.

#### Description of Task to be completed?

#### How should this be manually tested?

After cloning this repo., cd into the directory and RUN `npm run dev` command in the terminal:
- Using Postman, test every endpoint in the first section
  - PORT: 8080

#### Any background context you want to provide?

It seems each time a **query** is cached, and later a new **query** with some `options` is requested, the **old cached data** will be served.

This is due to the `second-key` in the `hget-hset` data-structure. It is an **object**, with only the query `filter` and `collection-name`

#### What are the relevant pivotal tracker stories?

#10

#### Screenshots (if appropriate)
#### Questions: